### PR TITLE
Assert Messages with printf style formatting

### DIFF
--- a/dunit/assertion.d
+++ b/dunit/assertion.d
@@ -37,19 +37,19 @@ class AssertException : Exception
  * Throws: AssertException otherwise
  */
 void assertTrue(string file = __FILE__, size_t line = __LINE__)
-		(const bool condition,  const string msg = null)
+        (const bool condition,  const string msg = null)
 {
-	assertTrueImpl!(file, line)(condition, msg);
+    assertTrueImpl!(file, line)(condition, msg);
 }
 
 void assertTrue(string file = __FILE__, size_t line = __LINE__, A...)
-		(const bool condition,  const string msg, A a)
+        (const bool condition,  const string msg, A a)
 {
-	assertTrueImpl!(file, line)(condition, xformat(msg, a));
+    assertTrueImpl!(file, line)(condition, xformat(msg, a));
 }
 
 void assertTrueImpl(string file, size_t line)
-		(const bool condition,  const string msg)
+        (const bool condition,  const string msg)
 {
     if (condition)
         return;
@@ -62,19 +62,19 @@ void assertTrueImpl(string file, size_t line)
  * Throws: AssertException otherwise
  */
 void assertFalse(string file = __FILE__, size_t line = __LINE__)
-		(const bool condition,  const string msg = null)
+        (const bool condition,  const string msg = null)
 {
-	assertFalseImpl!(file, line)(condition, msg);
+    assertFalseImpl!(file, line)(condition, msg);
 }
 
 void assertFalse(string file = __FILE__, size_t line = __LINE__, A...)
-		(const bool condition,  const string msg, A a)
+        (const bool condition,  const string msg, A a)
 {
-	assertFalseImpl!(file, line)(condition, xformat(msg, a));
+    assertFalseImpl!(file, line)(condition, xformat(msg, a));
 }
 
 void assertFalseImpl(string file, size_t line)
-		(const bool condition,  const string msg)
+        (const bool condition,  const string msg)
 {
     if (!condition)
         return;
@@ -91,6 +91,7 @@ unittest
             collectExceptionMsg!AssertException(assertTrue(false)));
 
     assertFalse(false);
+    assertFalse(false, "print%c assert messages", 'f');
     assertEquals("Assertion failure",
             collectExceptionMsg!AssertException(assertFalse(true)));
 }
@@ -99,8 +100,20 @@ unittest
  * Asserts that the values are equal.
  * Throws: AssertException otherwise
  */
+void assertEquals(T, U, string file = __FILE__, size_t line = __LINE__, A...)
+    (T expected, U actual, string msg, A a)
+{
+    assertEqualsImpl!(T,U,file,line)(expected, actual, xformat(msg, a));
+}
+
 void assertEquals(T, U, string file = __FILE__, size_t line = __LINE__)
-	(T expected, U actual,  string msg = null)
+    (T expected, U actual,  string msg = null)
+{
+    assertEqualsImpl!(T,U,file,line)(expected, actual, msg);
+}
+
+void assertEqualsImpl(T, U, string file, size_t line)
+    (T expected, U actual,  string msg)
 {
     if (expected == actual)
         return;
@@ -108,12 +121,13 @@ void assertEquals(T, U, string file = __FILE__, size_t line = __LINE__)
     string header = (msg.empty) ? null : msg ~ "; ";
 
     fail(header ~ "expected: <" ~ to!string(expected) ~ "> but was: <" 
-		~ to!string(actual) ~ ">", file, line);
+        ~ to!string(actual) ~ ">", file, line);
 }
 
 unittest
 {
     assertEquals("foo", "foo");
+    assertEquals("foo", "foo", "print%c style assert message", 'f');
     assertEquals("expected: <foo> but was: <bar>",
             collectExceptionMsg!AssertException(assertEquals("foo", "bar")));
 
@@ -137,7 +151,20 @@ unittest
  * Throws: AssertException otherwise
  */
 void assertArrayEquals(T, U, string file = __FILE__, size_t line = __LINE__)
-		(const(T[]) expecteds, const(U[]) actuals, string msg = null)
+        (const(T[]) expecteds, const(U[]) actuals, string msg = null)
+{
+    assertArrayEqualsImpl!(T,U,file,line)(expecteds, actuals, msg);
+}
+
+void assertArrayEquals(T, U, string file = __FILE__, size_t line =
+        __LINE__, A...)
+        (const(T[]) expecteds, const(U[]) actuals, string msg, A a)
+{
+    assertArrayEqualsImpl!(T,U,file,line)(expecteds, actuals, xformat(msg,a));
+}
+
+void assertArrayEqualsImpl(T, U, string file, size_t line)
+        (const(T[]) expecteds, const(U[]) actuals, string msg)
 {
     string header = (msg.empty) ? null : msg ~ "; ";
 
@@ -157,35 +184,54 @@ unittest
     double[] actuals = [1, 2, 3];
 
     assertArrayEquals(expecteds, actuals);
+    assertArrayEquals(expecteds, actuals, "print%c like message", 'f');
     assertEquals("array mismatch at index 1; expected: <2> but was: <2.3>",
-            collectExceptionMsg!AssertException(assertArrayEquals(expecteds, [1, 2.3])));
+            collectExceptionMsg!AssertException(assertArrayEquals(expecteds, 
+            [1, 2.3])));
     assertEquals("array length mismatch; expected: <3> but was: <2>",
-            collectExceptionMsg!AssertException(assertArrayEquals(expecteds, [1, 2])));
+            collectExceptionMsg!AssertException(assertArrayEquals(expecteds, 
+            [1, 2])));
     assertEquals("array mismatch at index 2; expected: <r> but was: <z>",
-            collectExceptionMsg!AssertException(assertArrayEquals("bar", "baz")));
+            collectExceptionMsg!AssertException(
+            assertArrayEquals("bar", "baz")));
 }
 
 /**
  * Asserts that the value is null.
  * Throws: AssertException otherwise
  */
-void assertNull(T, string file = __FILE__, size_t line = __LINE__)
-		(T actual,  string msg = null)
+void assertNull(T, string file = __FILE__, size_t line = __LINE__, A...)
+        (T actual,  string msg, A a)
 {
-    if (actual is null)
-        return;
+    assertNullImpl!(T, true, file, line)(actual, xformat(msg, a));
+}
 
-    fail(msg, file, line);
+void assertNull(T, string file = __FILE__, size_t line = __LINE__)
+        (T actual,  string msg = null)
+{
+    assertNullImpl!(T, true, file, line)(actual, msg);
 }
 
 /**
  * Asserts that the value is not null.
  * Throws: AssertException otherwise
  */
-void assertNotNull(T, string file = __FILE__, size_t line = __LINE__)
-		(T actual,  string msg = null)
+void assertNotNull(T, string file = __FILE__, size_t line = __LINE__, A...)
+        (T actual,  string msg, A a)
 {
-    if (actual !is null)
+    assertNullImpl!(T, false, file, line)(actual, xformat(msg, a));
+}
+
+void assertNotNull(T, string file = __FILE__, size_t line = __LINE__)
+        (T actual,  string msg = null)
+{
+    assertNullImpl!(T, false, file, line)(actual, msg);
+}
+
+void assertNullImpl(T, bool n, string file = __FILE__, size_t line = __LINE__)
+        (T actual,  string msg = null)
+{
+    if ((actual is null) == n)
         return;
 
     fail(msg, file, line);
@@ -196,10 +242,12 @@ unittest
     Object foo = new Object();
     
     assertNull(null);
+    assertNull(null, "print%c like message", 'f');
     assertEquals("Assertion failure",
             collectExceptionMsg!AssertException(assertNull(foo)));
 
     assertNotNull(foo);
+    assertNotNull(foo, "print%c like message", 'f');
     assertEquals("Assertion failure",
             collectExceptionMsg!AssertException(assertNotNull(null)));
 }
@@ -208,32 +256,49 @@ unittest
  * Asserts that the values are the same.
  * Throws: AssertException otherwise
  */
-void assertSame(T, U, string file = __FILE__, size_t line = __LINE__)
-		(T expected, U actual,  string msg = null)
+void assertSame(T, U, string file = __FILE__, size_t line = __LINE__,A...)
+        (T expected, U actual, string msg, A a)
 {
-    if (expected is actual)
-        return;
+    assertSameImpl!(T, U, true, file, line)(expected, actual, xformat(msg, a));
+}
 
-    string header = (msg.empty) ? null : msg ~ "; ";
-
-    fail(header ~ "expected same: <" ~ to!string(expected) ~ "> was not: <"~ to!string(actual) ~ ">",
-            file, line);
+void assertSame(T, U, string file = __FILE__, size_t line = __LINE__)
+        (T expected, U actual,  string msg = null)
+{
+    assertSameImpl!(T, U, true, file, line)(expected, actual, msg);
 }
 
 /**
  * Asserts that the values are not the same.
  * Throws: AssertException otherwise
  */
-void assertNotSame(T, U, string file = __FILE__, size_t line = __LINE__)
-		(T expected, U actual,  string msg = null)
+void assertNotSame(T, U, string file = __FILE__, size_t line = __LINE__,A...)
+        (T expected, U actual, string msg, A a)
 {
-    if (expected !is actual)
+    assertSameImpl!(T, U, false, file, line)(expected, actual, xformat(msg, a));
+}
+
+void assertNotSame(T, U, string file = __FILE__, size_t line = __LINE__)
+        (T expected, U actual,  string msg = null)
+{
+    assertSameImpl!(T, U, false, file, line)(expected, actual, msg);
+}
+
+void assertSameImpl(T, U, bool same, string file, size_t line)
+        (T expected, U actual,  string msg)
+{
+    if ((expected is actual) == same)
         return;
 
     string header = (msg.empty) ? null : msg ~ "; ";
 
-    fail(header ~ "expected not same",
-            file, line);
+    static if(same) {
+        fail(header ~ xformat("expected same: <%s> was not: <%s>",
+            expected, actual), file, line);
+    } else {
+        fail(header ~ xformat("expected not same: <%s> was: <%s>",
+            expected, actual), file, line);
+    }
 }
 
 unittest
@@ -242,11 +307,13 @@ unittest
     Object bar = new Object();
 
     assertSame(foo, foo);
+    assertSame(foo, foo, "print%c like message", 'f');
     assertEquals("expected same: <object.Object> was not: <object.Object>",
             collectExceptionMsg!AssertException(assertSame(foo, bar)));
 
     assertNotSame(foo, bar);
-    assertEquals("expected not same",
+    assertNotSame(foo, bar, "print%c like message", 'f');
+    assertEquals("expected not same: <object.Object> was: <object.Object>",
             collectExceptionMsg!AssertException(assertNotSame(foo, foo)));
 }
 
@@ -283,8 +350,8 @@ unittest
  * Throws: AssertException when the probe fails to become true before timeout
  */
 public static void assertEventually(string file = __FILE__, 
-		size_t line = __LINE__)
-		(bool delegate() probe, 
+        size_t line = __LINE__)
+        (bool delegate() probe, 
         Duration timeout = dur!"msecs"(500), Duration delay = dur!"msecs"(10), 
         string msg = null)
 {
@@ -292,7 +359,7 @@ public static void assertEventually(string file = __FILE__,
    
     while (!probe()) {
         Duration elapsedTime = cast(Duration)(TickDuration.currSystemTick() - 
-			startTime);
+            startTime);
 
         if (elapsedTime >= timeout) {
             if (msg.empty) {
@@ -310,5 +377,6 @@ unittest
     assertEventually({ static count = 0; return ++count > 42; });
 
     assertEquals("timed out",
-            collectExceptionMsg!AssertException(assertEventually({ return false; })));
+        collectExceptionMsg!AssertException(
+        assertEventually({ return false; })));
 }


### PR DESCRIPTION
For easier more outspoken error messages asserts now have printf style formatting.
This pull request also removes some symmetric code paths. 

Old api has not changed
